### PR TITLE
fix: remove double total interest calculation

### DIFF
--- a/loan/loan.go
+++ b/loan/loan.go
@@ -209,9 +209,6 @@ func NewLoan(loanAmount float64, nominalRate float64, term int, startDate time.T
 		finalPayment = monthlyPayment
 	}
 	payments, totalInterest := calculatePayments(loanAmount, startDate, daysUntilFirstPayment, nominalRate, term, finalPayment, nextPaymentDateWithEndOfMonth)
-	for _, payment := range payments {
-		totalInterest += payment.InterestAmount()
-	}
 
 	simpleAPR := simpleAPR(loanAmount, monthlyPayment, term, nominalRate)
 	bisectSimpleAPR := bisect(lowerAPRBound, upperAPRBound, aprThreshold, simplePresentValue(loanAmount, nominalRate, term, monthlyPayment, finalPayment, daysUntilFirstPayment))

--- a/loan/loan_test.go
+++ b/loan/loan_test.go
@@ -17,8 +17,8 @@ func TestMonthlyPayment(t *testing.T) {
 
 func TestTotalInterest(t *testing.T) {
 	loan := NewLoan(1000, 0.1, 12, time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC), 30, 0, 0.0, 0.5, 0.0001)
-	if math.Abs(loan.TotalInterest()-109.981294) > 0.000001 {
-		t.Errorf("TotalInterest() = %f; want 109.981294", loan.TotalInterest())
+	if math.Abs(loan.TotalInterest()-54.990647) > 0.000001 {
+		t.Errorf("TotalInterest() = %f; want 54.990647", loan.TotalInterest())
 	}
 }
 


### PR DESCRIPTION
Total interest calculated is double what it should be. This is caused by a duplicate addition assignment.